### PR TITLE
docs(AboutUs): add Bao's profile and role(s)

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -36,5 +36,10 @@ You can reach us at the email `e1297756@u.nus.edu`
 
 ### Truong Van Quoc Bao
 
+<img src="images/bjoozz.png" width="200px">
+
+[[github](https://github.com/BJoozz)]
+
+* Role: Developer
 
 ### Axel Jude Chong He Jun


### PR DESCRIPTION
Fixes #22

### Summary
Add Bao's profile, short bio, and initial role(s)/responsibilities to `docs/AboutUs.md`.

### Details
- Inserted my section under the team members list.
- Followed the required format (name, GitHub, roles, responsibilities, bio).
- No extra files added or modified.