### PR TITLE
Add Session value object and unit tests

### DIFF
--- a/src/main/java/seedu/address/model/person/Session.java
+++ b/src/main/java/seedu/address/model/person/Session.java
@@ -3,6 +3,10 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+/**
+ * Represents a Person's session number in TAConnect.
+ * Guarantees: immutable; is valid as declared in {@link #isValidSession(String)}
+ */
 public class Session {
 
 

--- a/src/main/java/seedu/address/model/person/Session.java
+++ b/src/main/java/seedu/address/model/person/Session.java
@@ -1,0 +1,57 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class Session {
+
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Sessions should start with a capital letter followed by 1–2 digits (e.g., G17, F7).";
+    public static final String VALIDATION_REGEX = "[A-Z]\\d{1,2}";
+    public final String value;
+
+    /**
+     * Constructs a {@code Session}.
+     *
+     * @param session A valid session number.
+     */
+    public Session(String session) {
+        requireNonNull(session);
+        checkArgument(isValidSession(session), MESSAGE_CONSTRAINTS);
+        this.value = session;
+    }
+
+    /**
+     * Returns true if a given string is a valid session number.
+     */
+    public static boolean isValidSession(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Session)) {
+            return false;
+        }
+
+        Session otherSession = (Session) other;
+        return value.equals(otherSession.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/SessionTest.java
+++ b/src/test/java/seedu/address/model/person/SessionTest.java
@@ -34,7 +34,7 @@ public class SessionTest {
         assertFalse(Session.isValidSession("G1A")); // letter after digit
 
         // valid sessions
-        assertTrue(Session.isValidSession("G1"));  // single digit
+        assertTrue(Session.isValidSession("G1")); // single digit
         assertTrue(Session.isValidSession("F7"));
         assertTrue(Session.isValidSession("E12"));
         assertTrue(Session.isValidSession("Z99"));

--- a/src/test/java/seedu/address/model/person/SessionTest.java
+++ b/src/test/java/seedu/address/model/person/SessionTest.java
@@ -1,0 +1,62 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SessionTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Session(null));
+    }
+
+    @Test
+    public void constructor_invalidSession_throwsIllegalArgumentException() {
+        String invalidSession = "";
+        assertThrows(IllegalArgumentException.class, () -> new Session(invalidSession));
+    }
+
+    @Test
+    public void isValidSession() {
+        // null session
+        assertThrows(NullPointerException.class, () -> Session.isValidSession(null));
+
+        // invalid sessions
+        assertFalse(Session.isValidSession("")); // empty string
+        assertFalse(Session.isValidSession(" ")); // spaces only
+        assertFalse(Session.isValidSession("g17")); // lowercase letter
+        assertFalse(Session.isValidSession("17G")); // digits before letter
+        assertFalse(Session.isValidSession("GG17")); // too many letters
+        assertFalse(Session.isValidSession("G173")); // more than 2 digits
+        assertFalse(Session.isValidSession("G1A")); // letter after digit
+
+        // valid sessions
+        assertTrue(Session.isValidSession("G1"));  // single digit
+        assertTrue(Session.isValidSession("F7"));
+        assertTrue(Session.isValidSession("E12"));
+        assertTrue(Session.isValidSession("Z99"));
+    }
+
+    @Test
+    public void equals() {
+        Session session = new Session("G17");
+
+        // same values -> returns true
+        assertTrue(session.equals(new Session("G17")));
+
+        // same object -> returns true
+        assertTrue(session.equals(session));
+
+        // null -> returns false
+        assertFalse(session.equals(null));
+
+        // different types -> returns false
+        assertFalse(session.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(session.equals(new Session("F7")));
+    }
+}


### PR DESCRIPTION
### Summary
Adds a new `Session` value object to represent a student's session identifier (e.g., G17, F7).
This class will later be used when extending the `Person` model and implementing the
`list s/SESSION` feature (UC5).

### Details
- Added `Session` class under `seedu.address.model.person`
- Added validation: sessions start with a capital letter followed by 1–2 digits
- Added `SessionTest` with constructor, validation, and equality tests
- No modifications to `Person` or storage components yet

### Testing
- Verified using `./gradlew test`
- All tests, including `SessionTest`, pass successfully

### Issue
Fixes #44
