### PR TITLE
Add test for MainApp.VERSION to satisfy Codecov patch check

### DIFF
--- a/src/test/java/seedu/address/MainAppVersionTest.java
+++ b/src/test/java/seedu/address/MainAppVersionTest.java
@@ -1,0 +1,13 @@
+package seedu.address;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class MainAppVersionTest {
+    @Test
+    public void versionConstant_isReachable() {
+        // Touches MainApp class init via field access (even if you don't assert exact numbers).
+        assertNotNull(MainApp.VERSION);
+    }
+}


### PR DESCRIPTION
This PR adds a simple JUnit test that accesses `MainApp.VERSION` to ensure the class’s static initializer is covered by tests.
Recent version bump PRs and their reverts failed the Codecov **patch coverage** check because the modified line (`VERSION = new Version(...)`) was never executed during tests.

### **Testing**

* `./gradlew test` passed locally.
* Codecov patch coverage expected to exceed 0% once this merges.
