### PR TITLE
docs: update UG, DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -283,6 +283,8 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* *` | tutor                                      | search contact list by _contact ID_ | locate details of _contacts_ by _contact ID_ without having to go through the entire list |
 | `* *` | tutor                                      | list all _contacts_ from the course | view all _contacts_ and their _contact details_ and _session_ in the contact list |
 | `* * *` | tutor                                      | list all _contacts_ by _session_ | view all _contacts_ and their _contact details_ in particular session in the contact list |
+| `* *` | tutor | navigate through previously entered commands | quickly reuse or edit past commands without retyping them |
+
 
 *{More to be added}*
 
@@ -430,6 +432,55 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
   * 4a1. TAConnect displays an error message indicating that data could not be accessed.
 
     Use case ends.
+
+
+**Use case: UC6 – Recall the previous command**
+
+**MSS**
+
+1. Tutor requests to show the previous command.
+2. TAConnect displays the previous command in the input area.
+   
+    Use case ends.
+
+**Extensions**
+
+1a. The current position is already at the oldest command.
+  * 1a1. TAConnect does nothing, the command box remains unchanged.
+    
+    Use case ends.
+1b. No command history exists.
+  * 1b1. TAConnect does nothing, the command box remains unchanged.
+
+    Use case ends.
+
+**Use case: UC7 – Move to the next newer command**
+
+**MSS**
+
+1. Tutor requests to show the next newer command.
+2. TAConnect displays the next newer command in the input area.
+
+    Use case ends.
+
+**Extensions**
+
+1a. The current position is already at the latest.
+  * 1a1. TAConnect does nothing, the command box remains unchanged.
+
+    Use case ends.
+
+
+**Use case: UC8 – Reuse a recalled command**
+
+**MSS**
+
+1. Tutor edits it or left the command as-is.
+2. Tutor presses **Enter**.
+2. TAConnect executes the shown command and displays the outcome.
+
+    Use case ends.
+
 
 ### Non-Functional Requirements
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,7 +3,7 @@ layout: page
 title: User Guide
 ---
 
-AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized for use via a Command Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3 can get your contact management tasks done faster than traditional GUI apps.
+TAConnect is a **desktop app for teaching assistants to manage students, sessions, and communication**, optimized for use via a Command Line Interface (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3 can get your contact management tasks done faster than traditional GUI apps.
 
 * Table of Contents
 {:toc}
@@ -87,11 +87,33 @@ Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
 
-### Listing all persons : `list`
+### Listing all contacts : `list`
 
-Shows a list of all persons in the address book.
+Displays all contacts currently stored in TAConnect.
 
 Format: `list`
+
+* The list is reset to the full view, clearing any filters applied by previous commands such as `find` or `listsession`.
+* Useful when you want to return to the complete contact list after filtering.
+
+Examples:
+* `list` — Displays all contacts in TAConnect.
+
+### Listing contacts by session : `listsession`
+
+Shows a list of all persons who belong to the specified session.
+
+Format: `listsession SESSION`
+
+* Displays only the contacts whose session field matches the given `SESSION` value.
+* Session names are **case-insensitive** and must follow the valid pattern `[A-Z]\d+` (e.g., `F1`, `G2`, `T10`), meaning a single uppercase letter followed by a number from **1 to 99** (without leading zeros)..
+* Contacts without a session (e.g., instructors or staff) will not appear in the result.
+* Useful for TAs who manage multiple tutorial or lab groups.
+
+Examples:
+* `listsession F20` — Lists all contacts in session F20.
+* `listsession G1` — Lists all contacts in session G1.
+
 
 ### Exporting the displayed contacts : `export`
 
@@ -173,6 +195,20 @@ Format: `undo`
 Examples:
 * `add n/John Doe ...` followed by `undo` removes the newly added contact and shows `Undo successful (reverted: add)`.
 * `delete 1 3-4` followed by `undo` restores the contacts removed by that delete and reports the exact command alias that was reverted (e.g., `delete`, `del`).
+
+### Command history (↑/↓)
+
+You can navigate your previously entered commands using the **UP** and **DOWN** arrow keys, similar to a terminal.
+
+* **UP:** Shows the previous command in history.
+* **DOWN:** Shows the next command in history; if you reach the end, your current unfinished input (buffer) is restored.
+* **Duplicates & empty lines:** Empty inputs are not saved. Consecutive identical commands are stored only once.
+* **Edits while browsing history:** If you edit the text at any time, those edits are preserved when you return to the end (buffer).
+
+Examples:
+1. Type `list` → press Enter. Press ↑ → `list` appears.
+2. Type `find alex` → press Enter. Press ↑ twice → `find alex`, then `list`.
+3. Press ↑ to view `list`, type `l` to modify it, then press ↓ until the end → your unfinished text appears again (e.g., `l`).
 
 ### Clearing all entries : `clear`
 


### PR DESCRIPTION
### 🧭 Summary

This PR updates some documentation to reflect the **v1.5 state of TAConnect**, following the Week 11 deliverables.

#### 🧾 User Guide
* Correct `list` command
* Added descriptions and examples for:
  * `listsession` command
  * `up` / `down` command (command history navigation)

#### 🛠 Developer Guide

* Updated user stories and use cases for `up` / `down` command.

**Fixes #113**
