### PR TITLE
Add tests and docs to cover changes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -99,16 +99,20 @@ Format: `help`
 
 Adds a contact to the contact list of TAConnect.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL t/TYPE [u/TELEGRAM_USERNAME] s/SESSION`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL t/TYPE [u/TELEGRAM_USERNAME] [s/SESSION]`
+
+Notes:
+* `s/SESSION` must be provided when the Type is `student` or `ta`.
+* `s/SESSION` must be omitted when the Type is `instructor` or `staff`.
 
 For convenience, a TA can also record telegram username, but it is an optional field.
 
 Examples:
-* Add contact type `student`: `add n/John Doe p/98765432 e/johnd@example.com t/student u/@johndoe s/F2`
+* Add contact type `student`: `add n/John Doe p/98765432 e/johnd@example.com t/student u/@johndoe s/F2` (session required)
 ![student.png](images/student.png)
 * Add contact type `ta`: `add n/David Shen p/23456789 e/davidshen@example.com t/ta s/L3`
 ![ta.png](images/ta.png)
-* Add contact type `instructor`: `add n/Betsy Crowe p/34560781 e/betsycrowe@example.com t/instructor`
+* Add contact type `instructor`: `add n/Betsy Crowe p/34560781 e/betsycrowe@example.com t/instructor` (session omitted)
 ![instructor.png](images/instructor.png)
 * Add contact type `staff`: `add n/Sophie Yuan p/17480572 e/sophie@example.come t/staff u/@yyssophie`
 ![staff.png](images/staff.png)

--- a/src/test/java/seedu/address/model/UserPrefsTest.java
+++ b/src/test/java/seedu/address/model/UserPrefsTest.java
@@ -1,9 +1,15 @@
 package seedu.address.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for {@link UserPrefs}.
+ */
 public class UserPrefsTest {
 
     @Test
@@ -18,4 +24,9 @@ public class UserPrefsTest {
         assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookFilePath(null));
     }
 
+    @Test
+    public void defaultAddressBookFilePath_isTaconnectJson() {
+        UserPrefs prefs = new UserPrefs();
+        assertEquals(Paths.get("data", "taconnect.json"), prefs.getAddressBookFilePath());
+    }
 }

--- a/src/test/java/seedu/address/ui/StatusBarFooterTest.java
+++ b/src/test/java/seedu/address/ui/StatusBarFooterTest.java
@@ -1,0 +1,75 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javafx.application.Platform;
+import javafx.scene.control.Label;
+
+/**
+ * Tests for {@link StatusBarFooter}.
+ */
+public class StatusBarFooterTest {
+
+    @BeforeAll
+    static void initFxToolkit() {
+        assumeTrue(!GraphicsEnvironment.isHeadless(), "Skipping JavaFX tests in headless environment");
+        try {
+            Platform.startup(() -> { });
+        } catch (IllegalStateException ignored) {
+            // JavaFX already started.
+        }
+    }
+
+    @Test
+    public void constructor_normalisesPathBeforeDisplaying() throws Exception {
+        Path rawPath = Paths.get("data", "..", "data", "taconnect.json");
+
+        StatusBarFooter footer = createFooter(rawPath);
+        Label saveLocationLabel = getSaveLocationLabel(footer);
+
+        assertEquals(Paths.get("data", "taconnect.json").toString(), saveLocationLabel.getText());
+    }
+
+    private StatusBarFooter createFooter(Path saveLocation) throws Exception {
+        StatusBarFooter[] holder = new StatusBarFooter[1];
+        runFxAndWait(() -> holder[0] = new StatusBarFooter(saveLocation));
+        return holder[0];
+    }
+
+    private Label getSaveLocationLabel(StatusBarFooter footer) throws Exception {
+        Field field = StatusBarFooter.class.getDeclaredField("saveLocationStatus");
+        field.setAccessible(true);
+        return (Label) field.get(footer);
+    }
+
+    private static void runFxAndWait(Runnable runnable) throws Exception {
+        if (Platform.isFxApplicationThread()) {
+            runnable.run();
+            return;
+        }
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            try {
+                runnable.run();
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("Timed out waiting for FX task");
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #145 
Adds StatusBarFooter/UserPrefs tests for the new defaults, updates docs to match the TAConnect jar/data filenames.